### PR TITLE
fix: configure pre-1.0 versioning for patch releases only

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,8 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
-      "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false
     }


### PR DESCRIPTION
## Changes

Updates Release Please configuration to stay in 0.0.x versions:

- Set `bump-minor-pre-major: true`
- Set `bump-patch-for-minor-pre-major: true`

This ensures:
- `feat:` commits → 0.0.2 → 0.0.3 (patch bump)
- `fix:` commits → 0.0.2 → 0.0.3 (patch bump)
- Only explicit `feat!:` or `BREAKING CHANGE:` → 0.1.0 or 1.0.0

We'll stay on 0.0.x until we're ready for a 1.0 release.