### PR TITLE
chore: add bootstrap-sha to start release-please from current state

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "b3ea38afb15a42a483ee8d60aa38377fbcb8e341",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Changes

Adds `bootstrap-sha` configuration to tell Release Please where to start looking for commits.

This fixes the issue where Release Please was creating PRs for 1.0.0 by:
- Setting bootstrap SHA to current commit
- This tells Release Please to ignore all historical commits
- Only future commits (starting from the config fix) will be included
- Next release will correctly be 0.0.3

The `bootstrap-sha` can be removed after the first successful release PR is merged.