### PR TITLE
fix: only warn if no skills directories were found

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -148,18 +148,29 @@ async function discoverSkills(basePaths: string[]): Promise<Skill[]> {
 
       foundPath = true;
     } catch (error) {
-			// ignore
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as any).code === "ENOENT"
+      ) {
+        // Directory does not exist, expected in some cases
+      } else {
+        console.warn(
+          `Unexpected error while scanning skills in ${basePath}:`,
+          error,
+        )
+      }
     }
   }
   
-	if (!foundPath) {
-		// Log warning but continue with other paths
-		console.warn(
-			`⚠️ Could find any skills directories. Tried:`,
-			...basePaths.map(path => `\n     ${path}`),
-			`\n   This is normal if none of the directories exist yet.`,
-		)
-	}
+  if (!foundPath) {
+    console.warn(
+      `⚠️ Could not find any skills directories. Tried:`,
+      ...basePaths.map(path => `\n     ${path}`),
+      `\n   This is normal if none of the directories exist yet.`,
+    )
+  }
 
   // Detect duplicate tool names
   const toolNames = new Set<string>()


### PR DESCRIPTION
### What does this PR do?

Updates the plugin to only emit a warning about missing skills directories if none were found.

### Why is this change needed?

It's a minor quality-of-life improvement.

### How has it been tested?

I installed the updated plugin locally and verified that it showed no warnings if I had a skills directory and showed a single warning if I had no skills directories. 

### Related issues (if applicable)

None.