### PR TITLE
fix: preserve agent context when loading skills and upgrade SDK to 1.0.126

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -219,6 +219,7 @@ export const SkillsPlugin: Plugin = async (ctx) => {
           ctx.client.session.prompt({
             path: { id: toolCtx.sessionID },
             body: {
+              agent: toolCtx.agent,
               noReply: true,
               parts: [{ type: "text", text }],
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "^0.15.18",
+        "@opencode-ai/sdk": "^1.0.126",
         "gray-matter": "^4.0.3",
         "zod": "^3.23.0"
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^0.15.18",
+        "@opencode-ai/plugin": "^1.0.126",
         "@types/bun": "^1.3.0",
         "bun-types": "^1.3.0",
         "typescript": "^5.9.3"
@@ -23,16 +23,16 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@opencode-ai/plugin": "^0.15.18"
+        "@opencode-ai/plugin": "^1.0.126"
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "0.15.18",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.15.18.tgz",
-      "integrity": "sha512-/d7XEz/G3XskF0BZ5JI/8c14NNvSBh1MBRkq9AA++543bw2eWhG79UXmTr2p0oNzsr0j0Dy1Q0nBwQdOIemiAg==",
+      "version": "1.0.126",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.0.126.tgz",
+      "integrity": "sha512-HFDbAeGqJBG01qCF5QIJF+cevrnLWioTqDRquYQHmOpxmard7OINQt57qmO7y+3ozyFMsAwUTTD9HK0xULHgvQ==",
       "dev": true,
       "dependencies": {
-        "@opencode-ai/sdk": "0.15.18",
+        "@opencode-ai/sdk": "1.0.126",
         "zod": "4.1.8"
       }
     },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "0.15.18",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-0.15.18.tgz",
-      "integrity": "sha512-zijPra2D0kGqB5ftK1rVeaooNRs0dY+sWYuWyqyGNCb8OcCqjtGHQiOyz3xZ0fDGF0VYd6fhr92qX0PhXoeLVQ=="
+      "version": "1.0.126",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.0.126.tgz",
+      "integrity": "sha512-W7Ac9seN/LGZDNEEE5HtNLzTskOO9+9jfEAkSUydWkrr+224cplN9ELRwrJsCl/o51xJzns22sJ5BRTqzT3bYQ=="
     },
     "node_modules/@types/bun": {
       "version": "1.3.0",
@@ -109,8 +109,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esprima": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -42,16 +42,16 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": "^0.15.18"
+    "@opencode-ai/plugin": "^1.0.126"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "^0.15.18",
+    "@opencode-ai/plugin": "^1.0.126",
     "@types/bun": "^1.3.0",
     "bun-types": "^1.3.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^0.15.18",
+    "@opencode-ai/sdk": "^1.0.126",
     "gray-matter": "^4.0.3",
     "zod": "^3.23.0"
   }


### PR DESCRIPTION
## Summary
- Fix agent context being lost when skills insert messages with `noReply: true`, which caused conversations to switch to the "build" agent
- Upgrade `@opencode-ai/sdk` and `@opencode-ai/plugin` from 0.15.18 to 1.0.126

## Root Cause
When `session.prompt()` is called without an `agent` parameter, opencode defaults to "build" agent. This fix explicitly passes `toolCtx.agent` to preserve the calling agent's context.

## Changes
- `package.json`: Upgraded SDK dependencies to 1.0.126
- `index.ts`: Added `agent: toolCtx.agent` to the `sendSilentPrompt` function